### PR TITLE
Fix TransactionBuilder.setFeeLimit and TronClient.getBlockBylatestNum

### DIFF
--- a/client/src/main/java/org/tron/tronj/client/Transaction/TransactionBuilder.java
+++ b/client/src/main/java/org/tron/tronj/client/Transaction/TransactionBuilder.java
@@ -31,28 +31,21 @@ public class TransactionBuilder {
     }
 
     public TransactionBuilder setFeeLimit(long feeLimit) {
-        transaction.toBuilder()
+        transaction = transaction.toBuilder()
             .setRawData(transaction.getRawData().toBuilder().setFeeLimit(feeLimit))
             .build();
         return this;
     } 
 
-    public TransactionBuilder setPermissionId(int permissionId) {
-        transaction.getRawData().toBuilder()
-            .setContract(0, transaction.getRawData().getContract(0).toBuilder().setPermissionId(permissionId))
-            .build();
-        return this;
-    }
-
     public TransactionBuilder setMemo(byte[] memo) {
-        transaction.toBuilder()
+        transaction = transaction.toBuilder()
             .setRawData(transaction.getRawData().toBuilder().setData(ByteString.copyFrom(memo)))
             .build();
         return this;
     }
 
     public TransactionBuilder setMemo(String memo) {
-        transaction.toBuilder()
+        transaction = transaction.toBuilder()
             .setRawData(transaction.getRawData().toBuilder().setData(ByteString.copyFromUtf8(memo)))
             .build();
         return this;

--- a/client/src/main/java/org/tron/tronj/client/TronClient.java
+++ b/client/src/main/java/org/tron/tronj/client/TronClient.java
@@ -415,7 +415,7 @@ public class TronClient {
         BlockListExtention blockListExtention = blockingStub.getBlockByLatestNum2(numberMessage);
 
         if(blockListExtention.getBlockCount() == 0){
-            throw new IllegalException();
+            throw new IllegalException("The number of latest blocks must be between 1 and 99, please check it.");
         }
         return blockListExtention;
     }


### PR DESCRIPTION
1. TransactionBuilder.setFeeLimit()/setMemo() work normally now
2. The param of TronClient.getBlockBylatestNum must between 1 and 99. The message had been added to the exception